### PR TITLE
Remove Control Flow Protection for x86_64 architecture

### DIFF
--- a/ShortcutRecorder.xcodeproj/project.pbxproj
+++ b/ShortcutRecorder.xcodeproj/project.pbxproj
@@ -661,9 +661,7 @@
 				);
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				"OTHER_CFLAGS[arch=arm64]" = (
-					"-fstrict-flex-arrays=3",
-					"-fstack-clash-protection",
-					"-fstack-protector-strong",
+					"$(inherited)",
 					"-mbranch-protection=standard",
 				);
 				"OTHER_CFLAGS[arch=x86_64]" = (
@@ -703,13 +701,7 @@
 				);
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				"OTHER_CFLAGS[arch=arm64]" = (
-					"-fstrict-flex-arrays=3",
-					"-fstack-clash-protection",
-					"-fstack-protector-strong",
-					"-fno-delete-null-pointer-checks",
-					"-fno-strict-overflow",
-					"-fno-strict-aliasing",
-					"-ftrivial-auto-var-init=zero",
+					"$(inherited)",
 					"-mbranch-protection=standard",
 				);
 				"OTHER_CFLAGS[arch=x86_64]" = (

--- a/ShortcutRecorder.xcodeproj/project.pbxproj
+++ b/ShortcutRecorder.xcodeproj/project.pbxproj
@@ -664,12 +664,6 @@
 					"$(inherited)",
 					"-mbranch-protection=standard",
 				);
-				"OTHER_CFLAGS[arch=x86_64]" = (
-					"-fstrict-flex-arrays=3",
-					"-fstack-clash-protection",
-					"-fstack-protector-strong",
-					"-fcf-protection=full",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kulakov.ShortcutRecorder;
 				PRODUCT_NAME = ShortcutRecorder;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -703,16 +697,6 @@
 				"OTHER_CFLAGS[arch=arm64]" = (
 					"$(inherited)",
 					"-mbranch-protection=standard",
-				);
-				"OTHER_CFLAGS[arch=x86_64]" = (
-					"-fstrict-flex-arrays=3",
-					"-fstack-clash-protection",
-					"-fstack-protector-strong",
-					"-fno-delete-null-pointer-checks",
-					"-fno-strict-overflow",
-					"-fno-strict-aliasing",
-					"-ftrivial-auto-var-init=zero",
-					"-fcf-protection=full",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kulakov.ShortcutRecorder;
 				PRODUCT_NAME = ShortcutRecorder;

--- a/ShortcutRecorder.xcodeproj/project.pbxproj
+++ b/ShortcutRecorder.xcodeproj/project.pbxproj
@@ -991,7 +991,6 @@
 					"-fno-strict-aliasing",
 					"-ftrivial-auto-var-init=zero",
 				);
-				"OTHER_CFLAGS[arch=x86_64]" = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
- Fix the build errors due to the use of `-fcf-protection=full` in OTHER_CFLAGS for x86_64 architecture, when building Release configurations with Xcode 16.2.
- Avoid duplicating OTHER_CFLAGS defined at the Project level in the ShortcutRecorder.framework target level; Uses `$(inherited)` instead. 